### PR TITLE
Fix Paste Statblock Button

### DIFF
--- a/frontend/src/views/StatblockEditorView.vue
+++ b/frontend/src/views/StatblockEditorView.vue
@@ -133,9 +133,10 @@ onUnmounted(() => {
 // Pasting BB statblock from clipboard
 const clipboardText = ref("");
 const permissionRead = usePermission("clipboard-read");
-const canPasteBBStatblock = computed(() => {
+const canPasteBBStatblock = computed(async () => {
 	try {
-		const parsed = JSON.parse(clipboardText.value);
+		const value = await navigator.clipboard.readText()
+		const parsed = JSON.parse(value);
 		return !!parsed?.isBB;
 	}
 	catch {
@@ -147,7 +148,8 @@ const importFromPaste = async () => {
 	if (!canPasteBBStatblock.value)
 		return;
 	try {
-		const parsed = JSON.parse(clipboardText.value);
+		const value = await navigator.clipboard.readText()
+		const parsed = JSON.parse(value);
 		delete parsed.isBB;
 		data.value = parsed;
 		toast.success("Successfully pasted creature!");

--- a/frontend/src/views/StatblockEditorView.vue
+++ b/frontend/src/views/StatblockEditorView.vue
@@ -34,6 +34,13 @@ onMounted(async () => {
 		rawInfo.value = cData;
 		await loadRawInfo();
 		loader.hide();
+		
+		try {
+			clipboardText.value = await navigator.clipboard.readText()
+		}
+		catch(error){
+			console.error("Unable to read clipboard text:", error)
+		}
 	}
 	else {
 		toast.error(`Error: ${error}`);
@@ -131,12 +138,11 @@ onUnmounted(() => {
 });
 
 // Pasting BB statblock from clipboard
-const clipboardText = ref("");
 const permissionRead = usePermission("clipboard-read");
-const canPasteBBStatblock = computed(async () => {
+const clipboardText = ref("");
+const canPasteBBStatblock = computed(() => {
 	try {
-		const value = await navigator.clipboard.readText()
-		const parsed = JSON.parse(value);
+		const parsed = JSON.parse(clipboardText.value);
 		return !!parsed?.isBB;
 	}
 	catch {
@@ -148,8 +154,7 @@ const importFromPaste = async () => {
 	if (!canPasteBBStatblock.value)
 		return;
 	try {
-		const value = await navigator.clipboard.readText()
-		const parsed = JSON.parse(value);
+		const parsed = JSON.parse(clipboardText.value);
 		delete parsed.isBB;
 		data.value = parsed;
 		toast.success("Successfully pasted creature!");
@@ -163,7 +168,7 @@ const onTabFocus = async () => {
 	if (document.hidden)
 		return;
 	setTimeout(async () => {
-		if (!document.hasFocus()) {
+		if (document.hasFocus()) {
 			try {
 				clipboardText.value = await navigator.clipboard.readText();
 			}


### PR DESCRIPTION
### Summary
Clipboard loses the value when moving between statblocks. Need to refetch the clipboard text.

### Changelog Entry
Re-check the navigator clipboard when moving between statblocks. Resolves #87

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.